### PR TITLE
Add backup and restore automation scripts

### DIFF
--- a/docs/ops-runbook.md
+++ b/docs/ops-runbook.md
@@ -1,3 +1,10 @@
 # Ops Runbook
 
 Operational procedures.
+
+## Database Backup & Restore
+
+Backup scripts reside in `scripts/backup.ps1` and `scripts/restore.ps1`.
+`backup.ps1` creates timestamped, compressed dumps and keeps the last N copies.
+`restore.ps1` stops the stack, restores the selected dump, and restarts services.
+An example task scheduler configuration is provided in `scripts/task_backup.xml`.

--- a/scripts/backup.ps1
+++ b/scripts/backup.ps1
@@ -1,1 +1,23 @@
-docker exec db pg_dump -U postgres postgres > backup.sql
+param(
+    [string]$BackupDir = "$PSScriptRoot\..\backups",
+    [int]$Keep = 7
+)
+
+if (-not (Test-Path $BackupDir)) {
+    New-Item -ItemType Directory -Path $BackupDir | Out-Null
+}
+
+$timestamp = Get-Date -Format 'yyyyMMddHHmmss'
+$dumpPath = Join-Path $BackupDir "postgres_$timestamp.sql"
+$archivePath = "$dumpPath.zip"
+
+Write-Host "Creating dump $dumpPath"
+docker exec db pg_dump -U postgres postgres > $dumpPath
+
+Write-Host "Compressing $dumpPath"
+Compress-Archive -Path $dumpPath -DestinationPath $archivePath
+Remove-Item $dumpPath
+
+# Cleanup old backups
+$archives = Get-ChildItem $BackupDir -Filter 'postgres_*.sql.zip' | Sort-Object LastWriteTime -Descending
+$archives | Select-Object -Skip $Keep | Remove-Item

--- a/scripts/restore.ps1
+++ b/scripts/restore.ps1
@@ -1,1 +1,28 @@
-docker exec -i db psql -U postgres postgres < backup.sql
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$BackupFile
+)
+
+if (-not (Test-Path $BackupFile)) {
+    Write-Error "Backup file not found"
+    exit 1
+}
+
+$tmp = $null
+if ($BackupFile -like '*.zip') {
+    $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+    Expand-Archive $BackupFile $tmp
+    $sql = Get-ChildItem $tmp -Filter *.sql | Select-Object -First 1
+    $BackupFile = $sql.FullName
+}
+
+docker compose down
+
+docker compose up -d db
+
+Write-Host "Restoring $BackupFile"
+docker exec -i db psql -U postgres postgres < $BackupFile
+
+docker compose up -d
+
+if ($tmp) { Remove-Item -Recurse -Force $tmp }

--- a/scripts/task_backup.xml
+++ b/scripts/task_backup.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <Triggers>
+    <CalendarTrigger>
+      <StartBoundary>2025-01-01T02:00:00</StartBoundary>
+      <Enabled>true</Enabled>
+      <ScheduleByDay>
+        <DaysInterval>1</DaysInterval>
+      </ScheduleByDay>
+    </CalendarTrigger>
+  </Triggers>
+  <Actions Context="Author">
+    <Exec>
+      <Command>powershell.exe</Command>
+      <Arguments>-File "C:\\scripts\\backup.ps1"</Arguments>
+    </Exec>
+  </Actions>
+</Task>


### PR DESCRIPTION
## Summary
- add `backup.ps1` for timestamped, compressed backups and rotation
- add `restore.ps1` to restore dumps and restart docker compose stack
- include `task_backup.xml` example for Windows Task Scheduler
- document database backup and restore procedure in ops runbook

## Testing
- `git status --short`
- `git log -1 --stat`

Codex couldn't run PowerShell or Docker commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_688058bc424883259df2b402c967f25a